### PR TITLE
[CI] fix pip error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install requirements
         run:  |
           python -V
-          pip install pip build setuptools twine packaging -U
+          pip install build setuptools twine packaging -U
 
       - name: Compile
         run: |


### PR DESCRIPTION
ERROR: To modify pip, please run the following command: C:\hostedtoolcache\windows\Python\3.10.11\x64\python.exe -m pip install pip build setuptools twine packaging -U

@Qubitium 