### PR TITLE
sync/downgrade setuptools depend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "PyPcre"
-version = "0.3.0"
+version = "0.3.1"
 description = "Modern, GIL-friendly, Fast Python bindings for PCRE2 with auto caching and JIT of compiled patterns."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 
 [build-system]
-requires = ["setuptools>=80", "wheel", "cmake>=3.27", "ninja"]
+requires = ["setuptools>=70.2.0", "wheel", "cmake>=3.27", "ninja"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -13,7 +13,7 @@ version = "0.3.0"
 description = "Modern, GIL-friendly, Fast Python bindings for PCRE2 with auto caching and JIT of compiled patterns."
 readme = "README.md"
 requires-python = ">=3.9"
-license = "Apache-2.0"
+license = { text = "Apache-2.0" }
 authors = [
     { name = "ModelCloud", email = "qubitium@modelcloud.ai" },
 ]


### PR DESCRIPTION
Fix: Torch cuda128 wheels are downgrading setuptools to a version that is incompatible with PyPcre. Until Torch fixes this and upgrade to latest setuptools, we need to downgrade. 

https://github.com/huggingface/optimum/pull/2420#issuecomment-4248617358