### PR TITLE
Fix setuptools packaging metadata for Python 3.10+ and setuptools 81-84

### DIFF
--- a/pcre_ext/pcre2.c
+++ b/pcre_ext/pcre2.c
@@ -6051,7 +6051,7 @@ module_exec(PyObject *module)
         goto error_cache;
     }
 
-    if (PyModule_AddStringConstant(module, "__version__", "0.6.0") < 0) {
+    if (PyModule_AddStringConstant(module, "__version__", "0.6.1") < 0) {
         goto error_cache;
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "PyPcre"
-version = "0.6.0"
+version = "0.6.1"
 description = "Modern, GIL-friendly, Fast Python bindings for PCRE2 with auto caching and JIT of compiled patterns."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 
 [build-system]
-requires = ["setuptools>=77.0.1,<83", "wheel", "cmake>=3.27", "ninja"]
+requires = ["setuptools>=77.0.1,<85", "wheel", "cmake>=3.27", "ninja"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -12,7 +12,7 @@ name = "PyPcre"
 version = "0.6.0"
 description = "Modern, GIL-friendly, Fast Python bindings for PCRE2 with auto caching and JIT of compiled patterns."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 authors = [
     { name = "ModelCloud", email = "qubitium@modelcloud.ai" },
@@ -32,7 +32,7 @@ classifiers = [
 keywords = ["regex", "pcre2", "bindings"]
 
 [project.urls]
-Homepage = "https://github.com/ModelCloud/pcre"
+Homepage = "https://github.com/ModelCloud/PyPcre"
 
 [tool.setuptools]
 packages = ["pcre"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 
 [build-system]
-requires = ["setuptools>=77.0.1,<85", "wheel", "cmake>=3.27", "ninja"]
+requires = ["setuptools>=79.0.0,<85", "wheel", "cmake>=3.27", "ninja"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -308,4 +308,10 @@ EXTENSION = Extension(
     **collect_build_config(),
 )
 
-setup(ext_modules=[EXTENSION], cmdclass={"build_ext": build_ext})
+setup(
+    name="PyPcre",
+    version="0.6.0",
+    packages=["pcre"],
+    ext_modules=[EXTENSION],
+    cmdclass={"build_ext": build_ext},
+)

--- a/setup.py
+++ b/setup.py
@@ -310,7 +310,7 @@ EXTENSION = Extension(
 
 setup(
     name="PyPcre",
-    version="0.6.0",
+    version="0.6.1",
     packages=["pcre"],
     ext_modules=[EXTENSION],
     cmdclass={"build_ext": build_ext},


### PR DESCRIPTION
## Summary
Fix setuptools packaging metadata so `PyPcre` builds and installs cleanly with Python 3.10+ and all major `setuptools` releases from 79 through 82, and bump the package version to `0.6.1`.

- Update `[build-system] requires` to `setuptools>=79.0.0,<85` (keeping `wheel`, `cmake`, and `ninja`).
- Set `requires-python = ">=3.10"`.
- Add `name`, `version`, and `packages` to `setup()` in `setup.py` so `pip` 22 and legacy setuptools can read package metadata when `pyproject.toml` alone is not processed.
- Keep the extension build logic (`ext_modules`, `cmdclass`) unchanged.

Link to Devin session: https://app.devin.ai/sessions/ec254701cd0c4dbfaf9dc02b870bb623
Requested by: @Qubitium